### PR TITLE
Fix T8027 description, A4 name; update T8002, T8301 descriptions

### DIFF
--- a/_data/cores.yaml
+++ b/_data/cores.yaml
@@ -1025,7 +1025,7 @@ chip_ids:
 
   0x8027:
     name: t8027
-    description: A14X/Z
+    description: A12X/Z
     architecture:
 
     revisions:
@@ -1668,7 +1668,7 @@ chip_ids:
 
 
   0x8930:
-    name: s8930
+    name: s5l8930xsi
     description: A4
 
     securerom:

--- a/_data/cores.yaml
+++ b/_data/cores.yaml
@@ -453,7 +453,7 @@ chip_ids:
 
   0x8002:
     name: t8002
-    description: S2
+    description: S2 / T1
     architecture:
 
     revisions:
@@ -1474,7 +1474,7 @@ chip_ids:
 
   0x8301:
     name: t8301
-    description: S6 / S7
+    description: S6 / S7 / S8
     architecture:
 
     revisions:


### PR DESCRIPTION
### References

T8027: https://www.theiphonewiki.com/wiki/T8027
A4: https://www.theiphonewiki.com/wiki/S5L8930
T1: https://www.theiphonewiki.com/wiki/T8002
S8: https://www.theiphonewiki.com/wiki/T8301